### PR TITLE
Make max request unlimited

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ ADD requestbin  /opt/requestbin/requestbin/
 EXPOSE 8000
 
 WORKDIR /opt/requestbin
-CMD gunicorn -b 0.0.0.0:8000 --worker-class gevent --workers 1 --max-requests 1000 requestbin:app
+CMD gunicorn -b 0.0.0.0:8000 --worker-class gevent --workers 1 --max-requests 0 requestbin:app
 
 


### PR DESCRIPTION
Make the max request to unlimited. This may be the cause why the worker is restarting when running the webhook e2e tests.

Relates to: https://github.com/apaleo/webhook/issues/79